### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
 		"chalk": "^5.2.0",
 		"cors": "^2.8.5",
 		"express": "^4.19.2",
-		"lucide-static": "^0.424.0"
+		"lucide-static": "^0.424.0",
+		"express-rate-limit": "^7.5.0"
 	},
 	"devDependencies": {
 		"autoprefixer": "^10.4.19",

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,8 +1,18 @@
 import express from 'express';
 import path from 'path';
+import rateLimit from 'express-rate-limit';
 const router = express.Router();
 
 let __dirname = process.cwd();
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+// apply rate limiter to all requests
+router.use(limiter);
 
 router.get('/', (req, res) => {
 	res.sendFile(path.join(__dirname, 'public/index.html'));


### PR DESCRIPTION
Potential fix for [https://github.com/NightProxy/Space/security/code-scanning/2](https://github.com/NightProxy/Space/security/code-scanning/2)

To fix the problem, we need to introduce a rate-limiting middleware to the Express application. The `express-rate-limit` package is a well-known library that can be used to implement rate limiting. We will set up a rate limiter that restricts the number of requests a client can make within a specified time window. This will help prevent abuse and potential denial-of-service attacks.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `src/routes.js` file.
3. Set up a rate limiter with a reasonable configuration (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter to all routes in the `src/routes.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
